### PR TITLE
chore: add dependabot labels and changelog configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,24 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "pip"
     # Python dependencies are defined in `pyproject.toml` and `requirements.txt` at the repository root.
     directory: "/" # Location of Python package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "devcontainers"
     directory: "/.devcontainer"
     schedule:
       interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,36 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          configurationJson: |
+            {
+              "template": "# Changelog\n\n{{CHANGELOG}}\n\n<details>\n<summary>📦 Other changes</summary>\n\n{{UNCATEGORIZED}}\n\n</details>",
+              "categories": [
+                {
+                  "title": "🚀 Features",
+                  "labels": ["feature","enhancement"]
+                },
+                {
+                  "title": "🐛 Bug Fixes",
+                  "labels": ["bug","fix"]
+                },
+                {
+                  "title": "📚 Documentation",
+                  "labels": ["documentation","docs"]
+                },
+                {
+                  "title": "⬆️ Dependencies",
+                  "labels": ["dependencies"]
+                },
+                {
+                  "title": "🧰 Maintenance",
+                  "labels": ["chore","ci"]
+                }
+              ],
+              "exclude_labels": [
+                "pre-commit"
+              ]
+            }
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Add `labels: ["dependencies"]` and `commit-message.prefix: "chore(deps)"` to all dependabot ecosystems
- Add changelog configuration to publish workflow for categorized release notes